### PR TITLE
remove deployment-guide from menu

### DIFF
--- a/content/en/docs/home/_index.md
+++ b/content/en/docs/home/_index.md
@@ -22,11 +22,6 @@ cards:
     description: "Learn about MicroShift and its fundamental concepts."
     button: "View Getting Started"
     button_path: "/docs/getting-started"
-  - name: deployment-guide
-    title: "Deploy MicroShift"
-    description: "Get up and running with MicroShift."
-    button: "View Deployment Guide"
-    button_path: "/docs/deployment-guide"
   - name: user-documentation
     title: "MicroShift User Guide"
     description: "Look up common tasks and how to perform them."


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

This is currently broken, remove the deployment-guide from the docs menu, since it is now embedded in `getting-started` 