### PR TITLE
update download path for CRI-O CentOS repos

### DIFF
--- a/content/en/docs/developer-documentation/local-development.md
+++ b/content/en/docs/developer-documentation/local-development.md
@@ -59,8 +59,8 @@ export VERSION=1.22
 #### Centos8Stream
 
 ```bash
-sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/$OS/devel:kubic:libcontainers:stable.repo
-sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:$VERSION.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$VERSION/$OS/devel:kubic:libcontainers:stable:cri-o:$VERSION.repo
+sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/devel:kubic:libcontainers:stable.repo
+sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:$VERSION.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/devel:kubic:libcontainers:stable:cri-o:$VERSION.repo
 sudo dnf install cri-o
 ```
 


### PR DESCRIPTION
**Which issue(s) this PR addresses**:

It appears the download paths for the CentOS_8_Stream repositories has changed. This PR updates the developer docs for installing CRI-O.