### PR TITLE
clarify cri-o install, de-dupe oc,kubectl install and setting kubeconfig

### DIFF
--- a/content/en/docs/developer-documentation/build-install-container.md
+++ b/content/en/docs/developer-documentation/build-install-container.md
@@ -38,6 +38,16 @@ Build the MicroShift AIO container:
 ```Bash
 make microshift-aio
 ```
+## Tagging the Image
+
+It is necessary to tag the image as latest to ensure that the newly created image is used when starting MicroShift with systemd.
+
+```Bash
+IMAGE=$(podman images | grep micro | awk '{print $3}')
+podman tag ${IMAGE} quay.io/microshift/microshift:latest
+```
+
+
 
 ## Running the MicroShift Containers
 

--- a/content/en/docs/developer-documentation/build-install-container.md
+++ b/content/en/docs/developer-documentation/build-install-container.md
@@ -27,28 +27,42 @@ git clone https://github.com/redhat-et/microshift.git
 cd microshift
 ```
 
-Build the MicroShift container:
+Build the MicroShift image:
 
 ```Bash
 make microshift
 ```
 
-Build the MicroShift AIO container:
+Build the MicroShift bundled (All-In-One) image:
 
 ```Bash
 make microshift-aio
 ```
 ## Tagging the Image
 
-It is necessary to tag the image as latest to ensure that the newly created image is used when starting MicroShift with systemd.
+After building the MicroShift image, the `podman tag` command can be used to modify the image name to suit your needs. See the example below.
 
 ```Bash
 IMAGE=$(podman images | grep micro | awk '{print $3}')
 podman tag ${IMAGE} quay.io/microshift/microshift:latest
 ```
 
-
-
 ## Running the MicroShift Containers
 
-Now follow the [Getting Started]({{< ref "/docs/getting-started/" >}}) respective section of the User Documentation, substituting the released image in the documentation with your local image.
+Depending on which image version you built, follow the documentation to run the image.
+
+{{< tabs >}}
+{{% tab name="MicroShift Containerized" %}}
+
+Follow [Getting Started with MicroShift Containerized]({{< ref "/docs/getting-started/_index.md#launch-microshift-with-podman-and-systemd" >}})    
+Substitute the image name:tag in the systemd unit file at `/etc/system/systemd/microshift.service` with the newly built image name:tag.
+
+{{% /tab %}}
+{{% tab name="MicroShift Bundled Image (All-In-One)" %}}
+
+Follow [Using MicroShift for Application Development]({{< ref "/docs/getting-started/_index.md#using-microshift-for-application-development" >}})    
+Substitute the image name:tag in the podman command with the newly built image name:tag.
+
+
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/en/docs/developer-documentation/build-install-rpm.md
+++ b/content/en/docs/developer-documentation/build-install-rpm.md
@@ -44,13 +44,34 @@ packaging/rpm/_rpmbuild/RPMS/x86_64/microshift-*
 
 ## Installing the RPMs
 
-Enable the CRI-O repo:
+Enable the CRI-O repository:
+
+{{< tabs >}}
+{{% tab name="RHEL" %}}
 
 ```Bash
 command -v subscription-manager &> /dev/null \
-    && subscription-manager repos --enable rhocp-4.8-for-rhel-8-x86_64-rpms \
-    || sudo dnf module enable -y cri-o:1.21
+    && subscription-manager repos --enable rhocp-4.8-for-rhel-8-x86_64-rpms
 ```
+
+{{% /tab %}}
+{{% tab name="Fedora" %}}
+
+```Bash
+sudo dnf module enable -y cri-o:1.21
+```
+{{% /tab %}}
+{{% tab name="CentOS_8_Stream" %}}
+
+```Bash
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8_Stream/devel:kubic:libcontainers:stable.repo
+curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:1.21.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:1.21/CentOS_8_Stream/devel:kubic:libcontainers:stable:cri-o:1.21.repo
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+<br/>
 
 Install the MicroShift and the SELinux policies:
 
@@ -68,11 +89,16 @@ systemctl enable crio --now
 systemctl enable microshift --now
 ```
 
+To install OpenShift and Kubernetes clients, follow [Getting Started: Install Clients]({{< ref "/docs/getting-started/_index.md#install-clients" >}}).
+
+To configure the kubeconfig, follow [Getting Started: Copy Kubeconfig]({{< ref "/docs/getting-started/_index.md#copy-kubeconfig" >}}).
+
+It is now possible to run `oc` or `kubectl` commands against the MicroShift environment.
+
 Verify that MicroShift is running:
 
 ```sh
-export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig
-sudo oc get pods -A
+oc get pods -A
 ```
 
 You can stop MicroShift service with systemd:
@@ -82,10 +108,9 @@ systemctl stop microshift
 ```
 
 {{< note >}}
-
 - cluster data at `/var/lib/microshift` and `/var/lib/kubelet`, will not be deleted upon stopping services.
   Upon a restart, the cluster state will persist as long as the storage is intact.
-  {{< /note >}}
+{{< /note >}}
 
 Check MicroShift with
 

--- a/content/en/docs/developer-documentation/local-development.md
+++ b/content/en/docs/developer-documentation/local-development.md
@@ -26,11 +26,26 @@ For building MicroShift you need a system with a minimum of
 
 Install the build-time dependencies:
 
+{{< tabs >}}
+{{% tab name="RHEL" %}}
+
 ```Bash
 command -v subscription-manager &> /dev/null \
     && sudo subscription-manager repos --enable "codeready-builder-for-rhel-8-$(uname -m)-rpms"
 sudo dnf install -y git make golang
 ```
+
+{{% /tab %}}
+{{% tab name="Fedora, CentOS_8_Stream" %}}
+
+```Bash
+sudo dnf install -y git make golang
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+<br/>
 
 Clone the repository and `cd` into it:
 
@@ -51,15 +66,8 @@ make DEBUG=true
 
 ## Running MicroShift
 
-Install [CRI-O](https://github.com/cri-o/cri-o/blob/main/install.md):
-
-```Bash
-command -v subscription-manager &> /dev/null \
-    && subscription-manager repos --enable rhocp-4.8-for-rhel-8-x86_64-rpms \
-    || sudo dnf module enable -y cri-o:1.21
-sudo dnf install -y crio cri-tools podman
-sudo systemctl enable crio --now
-```
+MicroShift requires `CRI-O` to be installed and running on the host.    
+Refer to [Getting Started: Install CRI-O]({{< ref "/docs/getting-started/_index.md#install-cri-o" >}})
 
 Install the SELinux policies from RPM or build and install them from source:
 
@@ -79,6 +87,19 @@ sudo ./microshift run
 ```
 
 Now switch to a new terminal to access and use this development MicroShift cluster.
+
+- To install OpenShift and Kubernetes clients, follow [Getting Started: Install Clients]({{< ref "/docs/getting-started/_index.md#install-clients" >}}).
+
+- To configure the kubeconfig, follow [Getting Started: Copy  Kubeconfig]({{< ref "/docs/getting-started/_index.md#copy-kubeconfig" >}}).
+
+It is now possible to run `oc` or `kubectl` commands against the MicroShift environment.
+
+Verify that MicroShift is running:
+
+```sh
+oc get pods -A
+```
+
 Refer to the [MicroShift user documentation]({{< ref "/docs/user-documentation/_index.md" >}})
 
 ## Cleaning Up

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -72,6 +72,8 @@ sudo dnf install -y podman
 ```
 <br/>
 
+### Launch MicroShift with Podman and Systemd
+
 To have `systemd` start and manage MicroShift on Podman, run:
 
 ```Bash
@@ -82,6 +84,8 @@ sudo systemctl enable microshift --now
 
 {{% /tab %}}
 {{% tab name=".rpm" %}}
+
+### Launch MicroShift RPM with Systemd
 
 To have `systemd` start and manage MicroShift on an rpm-based host, run:
 


### PR DESCRIPTION
The commands to install CRI-O don't work for Centos8Stream, and for other OS, I've added a note to link the CRI-O install documentation.

The setting of the kubeconfig commands were duplicated and did not match, so converged those.

Added a link to install clients section, to refer to it from different sections.