### PR TITLE
Fix spelling of MacOS

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -95,7 +95,7 @@ To access the cluster, install the OpenShift client or kubectl.
 
 ```Bash
 curl -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
-tar -xzvf oc.tar.gz
+sudo tar -C /usr/local/bin -xzvf oc.tar.gz
 sudo install -t /usr/local/bin {kubectl,oc}
 ```
 
@@ -119,7 +119,7 @@ oc get pods -A
 ## Using MicroShift for Application Development
 
 For trying out MicroShift or using it as development tool, we provide a MicroShift image that bundles host dependencies like CRI-O
-and useful tools like the `oc` client, so it can run on most modern Linux distros, on OSX, and on Windows with `podman` or `docker` installed.
+and useful tools like the `oc` client, so it can run on most modern Linux distros, on MacOS, and on Windows with `podman` or `docker` installed.
 This bundled image is referred to as `aio` or `all-in-one` since it provides everything necessary to run MicroShift.
 The all-in-one image is meant for ephemeral test environments only. There is no way to update the image without disruption of workloads and loss of data.
 For production workloads, it is recommended to run with [MicroShift Containerized]({{< ref "/docs/getting-started/_index.md#launch-microshift-with-podman-and-systemd" >}}).
@@ -148,7 +148,7 @@ sudo podman cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig ./k
 oc get all -A --kubeconfig ./kubeconfig
 ```
 {{% /tab %}}
-{{% tab name="OSX" %}}
+{{% tab name="MacOS" %}}
 [Install `docker`](https://docs.docker.com/desktop/mac/install/) if necessary, then run MicroShift using:
 
 ```Bash


### PR DESCRIPTION
The Mac operating system has been called simply "MacOS" since 2016 (see
https://en.wikipedia.org/wiki/Macintosh_operating_systems#Mac_OS_X_/_OS_X_/_macOS).
