### PR TITLE
update kubeconfig cp command from container

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -105,7 +105,7 @@ Copy the kubeconfig to the default location that can be accessed without adminis
 
 ```Bash
 mkdir ~/.kube
-sudo cp /var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
+sudo podman cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
 sudo chown `whoami`: ~/.kube/config
 ```
 


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

With the merge of https://github.com/redhat-et/microshift/pull/457  the `/var/lib/microshift/...` is no longer on the host, have to cp the kubeconfig from the container instead. 