### PR TITLE
Required port for proper pod name resolution

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -74,7 +74,10 @@ sudo dnf install -y podman firewalld
 sudo curl -o /etc/systemd/system/microshift.service \
      https://raw.githubusercontent.com/redhat-et/microshift/main/packaging/systemd/microshift-containerized.service
 sudo systemctl enable firewalld --now
-sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
+sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --add-port=53/udp --permanent
+sudo firewall-cmd --zone=public --add-port=80/tcp --permanent
+sudo firewall-cmd --zone=public --add-port=443/tcp --permanent
+sudo firewall-cmd --zone=public --add-port=5353/udp --permanent
 sudo firewall-cmd --reload
 sudo systemctl enable microshift --now
 ```
@@ -87,13 +90,30 @@ To have `systemd` start and manage MicroShift on an rpm-based host, run:
 sudo dnf copr enable -y @redhat-et/microshift
 sudo dnf install -y microshift firewalld
 sudo systemctl enable firewalld --now
-sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
+sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --add-port=53/udp --permanent
+sudo firewall-cmd --zone=public --add-port=80/tcp --permanent
+sudo firewall-cmd --zone=public --add-port=443/tcp --permanent
+sudo firewall-cmd --zone=public --add-port=5353/udp --permanent
 sudo firewall-cmd --reload
 sudo systemctl enable microshift --now
 ```
 
 {{% /tab %}}
 {{< /tabs >}}
+
+### Firewall Rules
+It is always best practice to have firewalls enabled and only to allow the minimum set of ports necessary for MicroShift to operate. Depending on the MicroShift deployment additional ports can be opened.
+
+If external access to run `kubectl` or `oc` commands against MicroShift is required, you may need to add the following rule:
+```Bash
+sudo firewall-cmd --zone=public --permanent --add-port=6443/tcp
+```
+
+If access to services through NodePort is required, run the following to add the a rule for the port range:
+```Bash
+sudo firewall-cmd --zone=public --permanent --add-port=30000-32767/tcp
+```
+
 
 ### Install Clients
 

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -70,9 +70,12 @@ sudo systemctl enable crio --now
 To have `systemd` start and manage MicroShift on Podman, run:
 
 ```Bash
-sudo dnf install -y podman
+sudo dnf install -y podman firewalld
 sudo curl -o /etc/systemd/system/microshift.service \
      https://raw.githubusercontent.com/redhat-et/microshift/main/packaging/systemd/microshift-containerized.service
+sudo systemctl enable firewalld --now
+sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
+sudo firewall-cmd --reload
 sudo systemctl enable microshift --now
 ```
 
@@ -83,6 +86,9 @@ To have `systemd` start and manage MicroShift on an rpm-based host, run:
 ```Bash
 sudo dnf copr enable -y @redhat-et/microshift
 sudo dnf install -y microshift firewalld
+sudo systemctl enable firewalld --now
+sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16
+sudo firewall-cmd --reload
 sudo systemctl enable microshift --now
 ```
 

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -74,7 +74,7 @@ sudo dnf install -y podman firewalld
 sudo curl -o /etc/systemd/system/microshift.service \
      https://raw.githubusercontent.com/redhat-et/microshift/main/packaging/systemd/microshift-containerized.service
 sudo systemctl enable firewalld --now
-sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --add-port=53/udp --permanent
+sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --permanent
 sudo firewall-cmd --zone=public --add-port=80/tcp --permanent
 sudo firewall-cmd --zone=public --add-port=443/tcp --permanent
 sudo firewall-cmd --zone=public --add-port=5353/udp --permanent

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -64,6 +64,7 @@ sudo systemctl enable crio --now
 <br/>
 
 ### Deploying MicroShift
+The following steps will deploy MicroShift and enable `firewalld`. It is always best practice to have firewalls enabled and only to allow the minimum set of ports necessary for MicroShift to operate. `Iptables` can be used in place of `firewalld` if desired.
 
 {{< tabs >}}
 {{% tab name="Podman" %}}
@@ -102,7 +103,7 @@ sudo systemctl enable microshift --now
 {{< /tabs >}}
 
 ### Firewall Rules
-It is always best practice to have firewalls enabled and only to allow the minimum set of ports necessary for MicroShift to operate. Depending on the MicroShift deployment additional ports can be opened.
+Depending on the MicroShift deployment additional ports can be opened.
 
 If external access to run `kubectl` or `oc` commands against MicroShift is required, you may need to add the following rule:
 ```Bash

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -90,7 +90,7 @@ To have `systemd` start and manage MicroShift on an rpm-based host, run:
 sudo dnf copr enable -y @redhat-et/microshift
 sudo dnf install -y microshift firewalld
 sudo systemctl enable firewalld --now
-sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --add-port=53/udp --permanent
+sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --permanent
 sudo firewall-cmd --zone=public --add-port=80/tcp --permanent
 sudo firewall-cmd --zone=public --add-port=443/tcp --permanent
 sudo firewall-cmd --zone=public --add-port=5353/udp --permanent


### PR DESCRIPTION
Required firewalld rule. If rule is not in place errors like this appear 
```
E0124 20:05:20.326679       1 base_controller.go:253] ManagedClusterCreatingController reconciliation failed: Get "https://api.quick.octo-emerging.redhataicoe.com:6443/apis/cluster.open-cluster-management.io/v1/managedclusters/virtual-twin": dial tcp: lookup api.quick.octo-emerging.redhataicoe.com on 10.43.0.10:53: read udp 10.42.0.11:43798->10.43.0.10:53: i/o timeout
```

Once rule is in place error goes away