### PR TITLE
proper kubeconfig for rpm

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -103,11 +103,25 @@ sudo install -t /usr/local/bin {kubectl,oc}
 
 Copy the kubeconfig to the default location that can be accessed without administrator privilege.
 
+{{< tabs >}}
+{{% tab name="Podman" %}}
+
 ```Bash
 mkdir ~/.kube
 sudo podman cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
 sudo chown `whoami`: ~/.kube/config
 ```
+
+{{% /tab %}}
+{{% tab name=".rpm" %}}
+```Bash
+mkdir ~/.kube
+sudo cp /var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
+sudo chown `whoami`: ~/.kube/config
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 It is now possible to run kubectl or oc commands against the MicroShift environment.
 Verify that MicroShift is running:

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -117,7 +117,6 @@ sudo chown `whoami`: ~/.kube/config
 ```Bash
 mkdir ~/.kube
 sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig > ~/.kube/config
-sudo chown `whoami`: ~/.kube/config
 ```
 
 {{% /tab %}}

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -116,7 +116,7 @@ sudo chown `whoami`: ~/.kube/config
 {{% tab name=".rpm" %}}
 ```Bash
 mkdir ~/.kube
-sudo cp /var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
+sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig > ~/.kube/config
 sudo chown `whoami`: ~/.kube/config
 ```
 


### PR DESCRIPTION
We don't define the steps to get a proper kubeconfig for rpm based installations.