### PR TITLE
Replace MacOS with macOS

### DIFF
--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -71,7 +71,7 @@
     "WIP",
     "RFE",
     "OSX",
-    "MacOS",
+    "macOS",
     "kustomizer",
     "kustomize",
     "Podman",

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -132,7 +132,7 @@ oc get pods -A
 ## Using MicroShift for Application Development
 
 For trying out MicroShift or using it as development tool, we provide a MicroShift image that bundles host dependencies like CRI-O
-and useful tools like the `oc` client, so it can run on most modern Linux distros, on MacOS, and on Windows with `podman` or `docker` installed.
+and useful tools like the `oc` client, so it can run on most modern Linux distros, on macOS, and on Windows with `podman` or `docker` installed.
 This bundled image is referred to as `aio` or `all-in-one` since it provides everything necessary to run MicroShift.
 The all-in-one image is meant for ephemeral test environments only. There is no way to update the image without disruption of workloads and loss of data.
 For production workloads, it is recommended to run with [MicroShift Containerized]({{< ref "/docs/getting-started/_index.md#launch-microshift-with-podman-and-systemd" >}}).
@@ -161,7 +161,7 @@ sudo podman cp microshift:/var/lib/microshift/resources/kubeadmin/kubeconfig ./k
 oc get all -A --kubeconfig ./kubeconfig
 ```
 {{% /tab %}}
-{{% tab name="MacOS" %}}
+{{% tab name="macOS" %}}
 [Install `docker`](https://docs.docker.com/desktop/mac/install/) if necessary, then run MicroShift using:
 
 ```Bash

--- a/themes/docsy/userguide/content/en/docs/Getting started/_index.md
+++ b/themes/docsy/userguide/content/en/docs/Getting started/_index.md
@@ -117,7 +117,7 @@ This is the simplest approach, as the Docsy example site repo is a [template rep
     git clone --recurse-submodules --depth 1 <em>https://github.com/my/example.git</em>
     </pre>
 
-You can now edit your local versions of the site's source files. To preview your site, go to your site root directory and run `hugo server` ([see the known issues on MacOS](#known-issues)). By default, your site will be available at http://localhost:1313/. To push changes to your new repo, go to your site root directory and use `git push`.
+You can now edit your local versions of the site's source files. To preview your site, go to your site root directory and run `hugo server` ([see the known issues on macOS](#known-issues)). By default, your site will be available at http://localhost:1313/. To push changes to your new repo, go to your site root directory and use `git push`.
 
 #### Using the command line
 
@@ -140,7 +140,7 @@ To copy the example site:
         hugo server
     
 1. Preview your site in your browser at: http://localhost:1313/. You can use `Ctrl + c` to stop the Hugo server whenever you like.
-   [See the known issues on MacOS](#known-issues).
+   [See the known issues on macOS](#known-issues).
 
 1. Now that you have a site running, you can push it to a new repository:
 
@@ -230,7 +230,7 @@ cd myproject
 hugo server
 ```
     
-By default, your site will be available at http://localhost:1313/. [See the known issues on MacOS](#known-issues).
+By default, your site will be available at http://localhost:1313/. [See the known issues on macOS](#known-issues).
 
 ## Basic site configuration
 
@@ -277,11 +277,11 @@ To use your own Custom Search Engine, replace the value in the `gcs_engine_id` w
 
 ## Known issues
 
-### MacOS
+### macOS
 
 #### Errors: `too many open files` or `fatal error: pipe failed`
 
-By default, MacOS permits a small number of open File Descriptors. For larger sites, or when you're simultaneously running multiple applications,
+By default, macOS permits a small number of open File Descriptors. For larger sites, or when you're simultaneously running multiple applications,
 you might receive one of the following errors when you run [`hugo server`](https://gohugo.io/commands/hugo_server/) to preview your site locally:
 
 * POSTCSS v7 and earlier:


### PR DESCRIPTION
The correct spelling is macOS, instead of MacOS.