### PR TITLE
Clean up the oc installation steps

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -95,8 +95,7 @@ To access the cluster, install the OpenShift client or kubectl.
 
 ```Bash
 curl -O https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
-tar -xvzf openshift-client-linux.tar.gz -C /tmp
-sudo install /tmp/{kubectl,oc} /usr/local/bin
+sudo tar -xf openshift-client-linux.tar.gz -C /usr/local/bin oc kubectl
 ```
 
 ### Copy Kubeconfig

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -94,9 +94,9 @@ sudo systemctl enable microshift --now
 To access the cluster, install the OpenShift client or kubectl.
 
 ```Bash
-curl -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
-sudo tar -C /usr/local/bin -xzvf oc.tar.gz
-sudo install -t /usr/local/bin {kubectl,oc}
+curl -O https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz
+tar -xvzf openshift-client-linux.tar.gz -C /tmp
+sudo install /tmp/{kubectl,oc} /usr/local/bin
 ```
 
 ### Copy Kubeconfig


### PR DESCRIPTION
PR #112 introduced a change that made unnecessary to execute the install command.
The problem with tar -C is that it also uncompreses the README.md file.

This PR fixes the openshift client install steps, also uses the correct download link.