### PR TITLE
Explicitly mention x86_64 as supported arch

### DIFF
--- a/content/en/docs/developer-documentation/local-development.md
+++ b/content/en/docs/developer-documentation/local-development.md
@@ -16,7 +16,7 @@ description: Building and running the MicroShift binary for local development
 
 For building MicroShift you need a system with a minimum of
 
-- a supported 64-bit CPU architecture (amd64, arm64, or riscv64)
+- a supported 64-bit CPU architecture (amd64/x86_64, arm64, or riscv64)
 - a supported Linux OS (RHEL 8, CentOS Stream 8, or Fedora 34+)
 - 2 CPU cores
 - 3GB of RAM

--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -9,7 +9,7 @@ description: "MicroShift system requirements and deployment"
 
 To run MicroShift, you need a machine with at least:
 
-- a supported 64-bit<sup>2</sup> CPU architecture (amd64, arm64, or riscv64)
+- a supported 64-bit<sup>2</sup> CPU architecture (amd64/x86_64, arm64, or riscv64)
 - a supported OS (see below)
 - 2 CPU cores
 - 2GB of RAM


### PR DESCRIPTION
Signed-off-by: Ricardo Noriega <rnoriega@redhat.com>

For sake of clarity, let's show  `x86_64` as supported architecture for MicroShift.