### PR TITLE
Fix typo in docs - openshift-portability

### DIFF
--- a/content/en/docs/openshift-portability/_index.md
+++ b/content/en/docs/openshift-portability/_index.md
@@ -13,7 +13,7 @@ The design goals behind MicroShift diverge from those of OKD as a necessity of t
 
 MicroShift's deployment model differs significantly from OKD's.  [Openshift-install](https://github.com/openshift/okd#getting-started) fully automates OKD deployment on cloud or baremetal infrastructure and manages system dependencies and configuration.  It goes a long way to provide a streamlined installation model for users.  MicroShift, being a single binary, can be installed atomically and managed like any other app. The user is expected to have some basic knowledge of package installation tools (dnf, yum, rpm).
 
-The MicroShift [documention](https://microshift.io/docs/getting-started/#install-cri-o) provides a step-by-step recipe for preparing a system and installing the app on supported operating systems.
+The MicroShift [documentation](https://microshift.io/docs/getting-started/#install-cri-o) provides a step-by-step recipe for preparing a system and installing the app on supported operating systems.
 
 ## Control-Plane Services
 
@@ -29,7 +29,7 @@ The most notable difference between an OKD and MicroShift runtime are the lack o
 - openshift-api-server
 - kube-controller-manager
 - openshift-controller-manager
-- openshift-oath
+- openshift-oauth
 - [multicast dns](https://github.com/redhat-et/microshift/pull/429) (for multi-node enablement)
 
 ##### Node


### PR DESCRIPTION
The following susbtitutions has been made:
/documention/documentation/ 
/openshift-oath/openshift-oauth/



