### PR TITLE
typo s/openshift-oath/openshift-oauth/

### DIFF
--- a/content/en/docs/openshift-portability/_index.md
+++ b/content/en/docs/openshift-portability/_index.md
@@ -29,7 +29,7 @@ The most notable difference between an OKD and MicroShift runtime are the lack o
 - openshift-api-server
 - kube-controller-manager
 - openshift-controller-manager
-- openshift-oath
+- openshift-oauth
 - [multicast dns](https://github.com/openshift/microshift/pull/429) (for multi-node enablement)
 
 ##### Node


### PR DESCRIPTION
typo `s/openshift-oath/openshift-oauth/` on https://microshift.io/docs/openshift-portability/#control-plane