### PR TITLE
Enable firewalld before configuring firewalld

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -67,6 +67,8 @@ To have `systemd` start and manage MicroShift on an rpm-based host, run:
 ```Bash
 sudo dnf copr enable -y @redhat-et/microshift
 sudo dnf install -y microshift
+sudo dnf -y install firewalld
+sudo systemctl enable --now firewalld
 sudo firewall-cmd --zone=trusted --add-source=10.42.0.0/16 --permanent
 sudo firewall-cmd --zone=public --add-port=80/tcp --permanent
 sudo firewall-cmd --zone=public --add-port=443/tcp --permanent


### PR DESCRIPTION
Firewalld doesn't come installed on Centos 8 Streams by default on all systems. Instances launched in AWS, for example, do not have the package installed at all. Attempting to configure firewalld before it is installed and enabled results in an error. These added steps resolve that error.